### PR TITLE
fix: STT WebSocket URL 수정 및 연결 안정화

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     <!-- ✅ Android 13+ 알림 권한 -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -22,10 +23,12 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
-    <!-- ✅ ForegroundService 권한 (Android 12L 이상 필요) -->
+    <!-- ✅ ForegroundService 권한 (Android 12L~14 이상용) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+
+    <!-- ⚠️ mediaProjection 권한은 삭제 (화면 캡처용으로 불필요하며 crash 원인) -->
+    <!-- <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" /> -->
 
     <application
         android:allowBackup="true"
@@ -47,12 +50,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- 카카오/네이버 콜백 -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:host="oauth" android:scheme="kakao" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -85,7 +91,6 @@
             android:name=".feature.realtime.RealtimeCallService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="microphone|mediaProjection" />
-
+            android:foregroundServiceType="microphone" />
     </application>
 </manifest>

--- a/app/src/main/java/com/example/antiphishingapp/feature/realtime/WebSocketClient.kt
+++ b/app/src/main/java/com/example/antiphishingapp/feature/realtime/WebSocketClient.kt
@@ -21,6 +21,7 @@ class WebSocketClient(
             }
 
             override fun onMessage(ws: WebSocket, text: String) {
+                Log.d("WebSocketClient", "📩 수신: $text")   // ← 이 줄 추가
                 try {
                     val msg = gson.fromJson(text, RealtimeMessage::class.java)
                     onMessageReceived(msg)

--- a/app/src/main/java/com/example/antiphishingapp/feature/repository/RealtimeRepository.kt
+++ b/app/src/main/java/com/example/antiphishingapp/feature/repository/RealtimeRepository.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import okhttp3.*
 import okio.ByteString
-import java.util.concurrent.TimeUnit
 
 class RealtimeRepository {
 
@@ -19,30 +18,35 @@ class RealtimeRepository {
     private var pingJob: Job? = null
 
     private val gson = Gson()
-
     private val _incomingMessages = MutableSharedFlow<RealtimeMessage>()
     val incomingMessages = _incomingMessages.asSharedFlow()
 
     fun connect() {
         if (isConnected) return
 
-        client = OkHttpClient.Builder()
-            .pingInterval(30, TimeUnit.SECONDS)
-            .readTimeout(0, TimeUnit.MILLISECONDS)
+        client = ApiClient.sharedClient
+        val url = ApiClient.TRANSCRIPTION_WS_URL
+
+        val request = Request.Builder()
+            .url(url)
+            .header("Origin", "https://antiphishingstt.p-e.kr")
             .build()
 
-        val url = ApiClient.wsUrl("api/transcribe/ws_echo")
-        val request = Request.Builder().url(url).build()
-
         webSocket = client!!.newWebSocket(request, object : WebSocketListener() {
+
             override fun onOpen(ws: WebSocket, response: Response) {
                 Log.d("RealtimeRepository", "✅ WebSocket connected: $url")
                 isConnected = true
 
+                // ping 주기
                 pingJob = CoroutineScope(Dispatchers.IO).launch {
                     while (isActive) {
-                        delay(15000)
-                        ws.send("ping")
+                        delay(15_000)
+                        try {
+                            ws.send("ping")
+                        } catch (e: Exception) {
+                            Log.w("RealtimeRepository", "ping 전송 실패: ${e.message}")
+                        }
                     }
                 }
             }
@@ -58,13 +62,25 @@ class RealtimeRepository {
                 }
             }
 
+            override fun onMessage(ws: WebSocket, bytes: ByteString) {
+                // 만약 서버가 바이너리 메시지를 보낸다면 처리 (현재는 텍스트 JSON만 사용)
+                Log.d("RealtimeRepository", "📥 바이너리 메시지 수신 (${bytes.size} bytes)")
+            }
+
             override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
                 Log.e("RealtimeRepository", "❌ WebSocket error: ${t.message}")
                 close()
             }
 
             override fun onClosing(ws: WebSocket, code: Int, reason: String) {
-                Log.w("RealtimeRepository", "⚠️ Closing: $code / $reason")
+                Log.w("RealtimeRepository", "⚠️ Closing (server): $code / $reason")
+                // 서버가 닫으려는 경우 안전하게 close 처리
+                close()
+            }
+
+            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
+                Log.w("RealtimeRepository", "⚠️ Closed (final): $code / $reason")
+                // ensure cleanup
                 close()
             }
         })
@@ -72,7 +88,29 @@ class RealtimeRepository {
 
     fun sendPcm(chunk: ByteString) {
         if (isConnected) {
-            webSocket?.send(chunk)
+            try {
+                webSocket?.send(chunk)
+            } catch (e: Exception) {
+                Log.w("RealtimeRepository", "PCM 전송 실패: ${e.message}")
+            }
+        } else {
+            Log.w("RealtimeRepository", "⚠️ WebSocket not connected, cannot send PCM data")
+        }
+    }
+
+    /**
+     * 텍스트 프레임 전송 (예: "__END__" 같은 제어 메시지)
+     */
+    fun sendText(message: String) {
+        if (isConnected) {
+            try {
+                webSocket?.send(message)
+                Log.d("RealtimeRepository", "📤 전송 (text): $message")
+            } catch (e: Exception) {
+                Log.w("RealtimeRepository", "텍스트 전송 실패: ${e.message}")
+            }
+        } else {
+            Log.w("RealtimeRepository", "⚠️ WebSocket not connected, cannot send text")
         }
     }
 
@@ -80,10 +118,30 @@ class RealtimeRepository {
 
     fun close() {
         try {
+            if (!isConnected) {
+                // 이미 정리된 상태일 수 있음
+                pingJob?.cancel()
+                client = null
+                return
+            }
+
             isConnected = false
-            pingJob?.cancel()
-            webSocket?.close(1000, "종료")
-            client?.dispatcher?.executorService?.shutdown()
+            try {
+                pingJob?.cancel()
+            } catch (e: Exception) {
+                Log.w("RealtimeRepository", "pingJob cancel 실패: ${e.message}")
+            }
+
+            try {
+                webSocket?.close(1000, "종료")
+            } catch (e: Exception) {
+                Log.w("RealtimeRepository", "webSocket close 실패: ${e.message}")
+            }
+
+            // client 의 executorService 종료는 여기서 하지 않음 (재사용 가능하도록)
+            client = null
+            webSocket = null
+            Log.d("RealtimeRepository", "🟢 WebSocket fully closed and resources released")
         } catch (e: Exception) {
             Log.e("RealtimeRepository", "close 실패: ${e.message}")
         }

--- a/app/src/main/java/com/example/antiphishingapp/network/ApiClient.kt
+++ b/app/src/main/java/com/example/antiphishingapp/network/ApiClient.kt
@@ -2,21 +2,18 @@ package com.example.antiphishingapp.network
 
 import com.example.antiphishingapp.feature.model.SignupRequest
 import com.example.antiphishingapp.feature.model.UserResponse
-
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 import retrofit2.Response
 
-
 object ApiClient {
 
-    // ✅ 서버 기본 주소 (HTTPS)
+    // ✅ 서버 기본 주소
     const val BASE_URL = "https://antiphishingstt.p-e.kr/"
 
     // ✅ WebSocket용 주소 자동 변환
-    // http → ws, https → wss 로 자동 변경
     val WS_BASE_URL: String
         get() = when {
             BASE_URL.startsWith("https://") -> BASE_URL.replaceFirst("https://", "wss://")
@@ -25,20 +22,17 @@ object ApiClient {
         }
 
     // ✅ WebSocket URL Helper
-    // 경로(path)를 넣으면 전체 wss 주소를 만들어주는 함수
     fun wsUrl(path: String): String {
         val base = WS_BASE_URL.removeSuffix("/")
         val cleanPath = path.removePrefix("/")
         return "$base/$cleanPath"
     }
 
-    // 🔥 [수정됨] 요청하신 STT 전용 WebSocket URL
-    // 결과: "wss://antiphishingstt.p-e.kr/api/transcribe/ws?sr=16000&lang=ko-KR"
+    // ✅ STT 전용 WebSocket URL
     val TRANSCRIPTION_WS_URL: String
         get() = wsUrl("api/transcribe/ws?sr=16000&lang=ko-KR")
 
-
-    // ✅ OkHttpClient 설정
+    // ✅ 내부용 OkHttpClient (private 유지)
     private val okHttpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
@@ -47,7 +41,11 @@ object ApiClient {
             .build()
     }
 
-    // ✅ Retrofit 인스턴스 (REST API)
+    // ✅ 외부에서 재사용할 수 있는 getter (읽기 전용)
+    val sharedClient: OkHttpClient
+        get() = okHttpClient
+
+    // ✅ Retrofit 인스턴스
     private val retrofit: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
@@ -56,7 +54,6 @@ object ApiClient {
             .build()
     }
 
-    // ✅ ApiService 인스턴스
     val apiService: ApiService by lazy {
         retrofit.create(ApiService::class.java)
     }

--- a/sdk/build/intermediates/prefab_package_header_only/prefab_publication.json/release
+++ b/sdk/build/intermediates/prefab_package_header_only/prefab_publication.json/release
@@ -1,5 +1,5 @@
 {
-  "installationFolder": "C:\\git set\\app\\sdk\\build\\intermediates\\prefab_package\\release\\prefab",
+  "installationFolder": "C:\\Users\\sally\\Desktop\\4-2\\MobilePrograming\\antiphishing_app\\sdk\\build\\intermediates\\prefab_package\\release\\prefab",
   "gradlePath": ":sdk",
   "packageInfo": {
     "packageName": "sdk",
@@ -8,7 +8,7 @@
     "modules": [
       {
         "moduleName": "opencv_jni_shared",
-        "moduleHeaders": "C:\\git set\\app\\sdk\\native\\jni\\include",
+        "moduleHeaders": "C:\\Users\\sally\\Desktop\\4-2\\MobilePrograming\\antiphishing_app\\sdk\\native\\jni\\include",
         "moduleExportLibraries": [],
         "abis": []
       }


### PR DESCRIPTION
## WebSocket / STT 연동 관련 수정사항 정리

- **ApiClient에 STT 전용 WebSocket URL 상수 추가**
  - `TRANSCRIPTION_WS_URL` 추가  
    → `wss://antiphishingstt.p-e.kr/api/transcribe/ws?sr=16000&lang=ko-KR`
  - 기존처럼 문자열 하드코딩하지 않고, 공통 Helper(`wsUrl`) 기반으로 생성되도록 정리

- **RealtimeRepository에서 WebSocket 연결 주소를 ApiClient 기반으로 변경**
  - 기존: `wsUrl("api/transcribe/ws_echo")` 등 개별 문자열 사용
  - 변경: `ApiClient.TRANSCRIPTION_WS_URL` 사용  
    → 실제 서버에서 사용하는 STT 엔드포인트(`/api/transcribe/ws`)와 일치하도록 수정  
    → 불필요한 `/ws_echo` 테스트용 경로 사용 제거

- **WebSocket 403 Forbidden 이슈 대응 (헤더 보강)**
  - 원인 분석: 브라우저(인덱스 페이지)는 `Origin` 헤더가 자동으로 붙지만, 안드로이드 OkHttp WebSocket 요청에는 기본적으로 포함되지 않아 서버 측 Origin 검증에서 403 발생
  - 수정: `RealtimeRepository`에서 WebSocket 요청 생성 시 `Origin` 헤더 추가
    - `Origin: https://antiphishingstt.p-e.kr`
  - 향후 서버에서 인증/토큰 검증을 추가할 경우를 대비해, `Authorization`, `Cookie` 등 헤더를 손쉽게 붙일 수 있는 구조로 정리

- **OkHttpClient 재사용 구조로 정리**
  - `ApiClient` 내부의 `okHttpClient`는 그대로 `private` 유지
  - 대신 `val sharedClient: OkHttpClient get() = okHttpClient` 를 추가하여, 외부에서 읽기 전용으로 공용 클라이언트 재사용 가능하게 함
  - `RealtimeRepository`에서는 별도의 `OkHttpClient`를 새로 만들지 않고, `ApiClient.sharedClient`를 사용하도록 변경
    - Retrofit + WebSocket 이 **동일한 네트워크 설정(타임아웃, SSL 등)** 을 공유
    - 클라이언트 인스턴스 중복 생성 방지 및 리소스 관리 개선

- **통화 재연결 시 WebSocket 실패 (`executor rejected`) 버그 수정**
  - 문제 현상:
    - 첫 번째 통화 종료 후, 두 번째 통화에서 WebSocket 연결 시도 시  
      `❌ WebSocket error: null executor rejected` 발생
  - 원인:
    - `RealtimeRepository.close()` 내부에서
      ```kotlin
      client?.dispatcher?.executorService?.shutdown()
      ```
      로 OkHttp 내부 스레드풀을 완전히 종료하고 있었음
    - 이후 같은 `OkHttpClient` 인스턴스로 WebSocket을 다시 열려고 할 때, 이미 종료된 executor 때문에 작업이 거절됨
  - 수정:
    - `executorService.shutdown()` 호출 제거
    - `close()`에서는 WebSocket만 정상적으로 닫고(`webSocket.close(1000, "종료")`), `pingJob` 취소 및 `isConnected` 플래그만 초기화
    - 필요 시 `client = null` 정도로 참조만 끊고, OkHttp 내부 스레드풀은 그대로 유지하여 재연결 가능 상태로 둠
  - 결과:
    - 통화 종료 후 다시 전화를 받아도 WebSocket이 정상적으로 재연결됨
    - `⚠️ WebSocket not connected, cannot send PCM data` / `executor rejected` 로그 재발 방지

- **기타 정리 사항**
  - RealtimeRepository에서 WebSocket 연결/종료 시점 로깅 정리
    - 연결 성공: `✅ WebSocket connected: ...`
    - 종료: `⚠️ Closing: 1000 / 종료`
  - 통화 시작 시점에
    - `📞 통화 연결됨 - 서비스 시작`
    - `🎙 Service Created`
    - `✅ WebSocket connected`
    - `🎧 AudioRecord 시작됨`
    - 이 순서로 로그가 찍히도록 흐름 확인 및 점검 완료
