### PR TITLE
feat: 사용자 이름 표시를 위한 AuthViewModel 및 화면 구조 개선

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
 
     <application
         android:allowBackup="true"
+        android:name=".MyApplication"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/example/antiphishingapp/MyApplication.kt
+++ b/app/src/main/java/com/example/antiphishingapp/MyApplication.kt
@@ -1,0 +1,16 @@
+package com.example.antiphishingapp
+
+import android.app.Application
+
+class MyApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+
+    companion object {
+        lateinit var instance: MyApplication
+            private set
+    }
+}

--- a/app/src/main/java/com/example/antiphishingapp/feature/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/antiphishingapp/feature/repository/AuthRepository.kt
@@ -5,9 +5,12 @@ import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.example.antiphishingapp.feature.model.TokenResponse
+import com.example.antiphishingapp.feature.model.UserResponse
 import com.example.antiphishingapp.network.ApiClient
 
 /**
+ * AuthRepository
+ * ------------------------
  * 사용자 인증 토큰 (Access Token, Refresh Token)을 안전하게 저장하고 관리하는 Repository.
  * Context를 생성자로 받아 의존성을 주입받습니다.
  */
@@ -34,28 +37,13 @@ class AuthRepository(private val context: Context) {
         )
     }
 
-    // --- 네이버 State 저장 등 일반 설정을 위한 일반 SharedPreferences ---
+    // 네이버 State 저장 등 일반 설정을 위한 일반 SharedPreferences
     // 네이버 state 저장을 위해 사용 (민감 정보가 아니므로 일반 SharedPreferences 사용)
     private val appPrefs by lazy {
         context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
     }
 
-    /**
-     * 로그인 성공 후 토큰을 안전하게 저장합니다.
-     */
-    fun saveTokens(tokenResponse: TokenResponse) {
-        securePrefs.edit().apply {
-            putString(KEY_ACCESS_TOKEN, tokenResponse.accessToken)
-            putString(KEY_REFRESH_TOKEN, tokenResponse.refreshToken)
-            apply()
-        }
-    }
-
-    /**
-     * 로그인 성공 후 토큰과 자동 로그인 체크 여부를 저장
-     * @param tokenResponse 서버로부터 받은 토큰
-     * @param isAutoLogin 사용자가 자동 로그인 체크박스를 체크했는지 여부
-     */
+    // 로그인 성공 후 서버로부터 반환받은 토큰 및 자동 로그인 여부 저장
     fun saveTokens(tokenResponse: TokenResponse, isAutoLogin: Boolean) {
         securePrefs.edit().apply {
             putString(KEY_ACCESS_TOKEN, tokenResponse.accessToken)
@@ -65,25 +53,19 @@ class AuthRepository(private val context: Context) {
         }
     }
 
-    /**
-     * 저장된 Access Token을 반환합니다.
-     */
+    // 저장된 Access Token을 반환
     fun getAccessToken(): String? {
         // 토큰이 없으면 null 반환
         return securePrefs.getString(KEY_ACCESS_TOKEN, null)
     }
 
-    /**
-     * 저장된 Refresh Token을 반환합니다.
-     */
+    // 저장된 Refresh Token을 반환
     fun getRefreshToken(): String? {
         return securePrefs.getString(KEY_REFRESH_TOKEN, null)
     }
 
-    /**
-     * 토큰이 유효한지, 자동 로그인이 설정되어 있는지 확인
-     * 앱 시작 시 Splash 화면 등에서 이 함수를 호출하여 자동 로그인 여부를 판단
-     */
+    // 토큰이 유효한지, 자동 로그인이 설정되어 있는지 확인
+    // 앱 시작 시 Splash 화면 등에서 이 함수를 호출하여 자동 로그인 여부를 판단
     fun isAuthenticated(): Boolean {
         val hasToken = getAccessToken() != null
         val isAutoLogin = securePrefs.getBoolean(KEY_IS_AUTO_LOGIN, false)
@@ -92,36 +74,44 @@ class AuthRepository(private val context: Context) {
         return hasToken && isAutoLogin
     }
 
-    /**
-     * 저장된 모든 토큰을 삭제합니다 (로그아웃).
-     */
+    // 저장된 모든 토큰을 삭제
     fun clearTokens() {
         securePrefs.edit().clear().apply()
     }
 
-    // --- 네이버 State 및 일반 Key-Value 관리 메서드 (SocialLoginViewModel에서 사용) ---
+    // 로그인한 사용자의 정보를 가져옴
+    suspend fun getMe(): UserResponse? {
+        val token = getAccessToken() ?: return null
 
-    // 🚨 1. SharedPreferences에 Key-Value 저장 (SocialLoginViewModel.getNaverAuthUrl에서 state 저장 시 사용)
+        val response = ApiClient.apiService.getMe("Bearer $token")
+
+        return if (response.isSuccessful) {
+            response.body()
+        } else {
+            null
+        }
+    }
+
+
+    // 네이버 State 및 일반 Key-Value 관리 메서드 (SocialLoginViewModel에서 사용)
+
+    // 1. SharedPreferences에 Key-Value 저장 (SocialLoginViewModel.getNaverAuthUrl에서 state 저장 시 사용)
     fun saveValue(key: String, value: String) {
         appPrefs.edit().putString(key, value).apply()
     }
 
-    // 🚨 2. SharedPreferences에서 Key-Value 조회 (SocialLoginViewModel.handleCallbackUri에서 state 검증 시 사용)
+    // 2. SharedPreferences에서 Key-Value 조회 (SocialLoginViewModel.handleCallbackUri에서 state 검증 시 사용)
     fun getValue(key: String): String? {
         return appPrefs.getString(key, null)
     }
 
-    // 🚨 3. SharedPreferences에서 Key-Value 삭제
+    // 3. SharedPreferences에서 Key-Value 삭제
     fun clearValue(key: String) {
         appPrefs.edit().remove(key).apply()
     }
 
-
-    // --- 소셜 로그인 API 호출 메서드 ---
-    /**
-     * 소셜 인증 코드를 서버에 보내 JWT 토큰으로 교환합니다.
-     * (이 함수는 SocialLoginViewModel에서 호출됩니다.)
-     */
+    // 소셜 인증 코드를 서버에 보내 JWT 토큰으로 교환
+    // (이 함수는 SocialLoginViewModel에서 호출됩니다.)
     suspend fun exchangeCodeForToken(
         provider: String,
         code: String,

--- a/app/src/main/java/com/example/antiphishingapp/feature/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/antiphishingapp/feature/viewmodel/AuthViewModel.kt
@@ -1,0 +1,40 @@
+package com.example.antiphishingapp.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.antiphishingapp.feature.model.UserResponse
+import com.example.antiphishingapp.feature.repository.AuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class AuthViewModel(
+    application: Application
+) : AndroidViewModel(application) {
+
+    // ApplicationContext 주입 (LoginViewModel과 패턴을 맞춤)
+    private val authRepository = AuthRepository(application.applicationContext)
+
+    private val _user = MutableStateFlow<UserResponse?>(null)
+    val user: StateFlow<UserResponse?> = _user
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    init {
+        loadUser()   // 앱 초기 사용자 정보 로드
+    }
+
+    /** 서버에서 로그인 중인 사용자 정보 가져오기 */
+    fun loadUser() {
+        viewModelScope.launch {
+            _isLoading.value = true
+
+            val userInfo = authRepository.getMe()
+            _user.value = userInfo
+
+            _isLoading.value = false
+        }
+    }
+}

--- a/app/src/main/java/com/example/antiphishingapp/network/ApiService.kt
+++ b/app/src/main/java/com/example/antiphishingapp/network/ApiService.kt
@@ -33,51 +33,51 @@ data class SmsDetectResponse(
 
 interface ApiService {
 
-    // ✅ 서버 상태 확인 (GET /healthz)
+    // 서버 상태 확인 (GET /healthz)
     @GET("healthz")
     fun checkHealth(): Call<String>
 
-    // ✅ 단일 이미지 업로드 (POST /upload-image)
+    // 단일 이미지 업로드 (POST /upload-image)
     @Multipart
     @POST("upload-image")
     fun uploadImage(
         @Part file: MultipartBody.Part
     ): Call<ResponseBody>
 
-    // ✅ 여러 이미지 업로드 (POST /upload-images)
+    // 여러 이미지 업로드 (POST /upload-images)
     @Multipart
     @POST("upload-images")
     fun uploadMultipleImages(
         @Part files: List<MultipartBody.Part>
     ): Call<ResponseBody>
 
-    // ✅ 음성 파일 업로드 (POST /api/transcribe/upload)
+    // 음성 파일 업로드 (POST /api/transcribe/upload)
     @Multipart
     @POST("api/transcribe/upload")
     fun uploadAudioFile(
         @Part file: MultipartBody.Part
     ): Call<ResponseBody>
 
-    // ✅ 음성 변환 상태 조회 (GET /api/transcribe/status/{token})
+    // 음성 변환 상태 조회 (GET /api/transcribe/status/{token})
     @GET("api/transcribe/status/{token}")
     fun getTranscribeStatus(
         @Path("token") token: String
     ): Call<ResponseBody>
 
-    // ✅ 문서 분석 (POST /process-request)
+    // 문서 분석 (POST /process-request)
     @Multipart
     @POST("process-request")
     fun processRequest(
         @Part file: MultipartBody.Part
-    ): Call<AnalysisResponse> // ✅ 여기만 변경됨
+    ): Call<AnalysisResponse>
 
-    // ✅ 문자 내용 분석 (POST /api/sms/detect_json)
+    // 문자 내용 분석 (POST /api/sms/detect_json)
     @POST("api/sms/detect_json")
     fun detectSmsJson(
         @Body payload: SmsDetectRequest
     ): Call<SmsDetectResponse>
 
-    // ✅ 음성 파일 분석 (STT + 보이스피싱 분석)
+    // 음성 파일 분석 (STT + 보이스피싱 분석)
     @Multipart
     @POST("api/voice-phishing/analyze-audio")
     fun analyzeAudioFile(
@@ -108,4 +108,9 @@ interface ApiService {
         @Field("state") state: String
     ): Response<TokenResponse>
 
+    // 로그인한 사용자 정보를 가져옴 (GET /auth/me)
+    @GET("auth/me")
+    suspend fun getMe(
+        @Header("Authorization") token: String
+    ): Response<UserResponse>
 }

--- a/app/src/main/java/com/example/antiphishingapp/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/antiphishingapp/ui/main/MainScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -52,16 +53,20 @@ import com.example.antiphishingapp.theme.Grayscale800
 import com.example.antiphishingapp.theme.Grayscale900
 import com.example.antiphishingapp.theme.NPSFont
 import com.example.antiphishingapp.theme.Primary100
-import com.example.antiphishingapp.theme.Primary200
 import com.example.antiphishingapp.theme.Primary300
 import com.example.antiphishingapp.theme.Primary900
+import com.example.antiphishingapp.viewmodel.AuthViewModel
 
 
 @Composable
 fun MainScreen(
     navController: NavController,
-    onAnalysisComplete: (AnalysisResponse) -> Unit
+    onAnalysisComplete: (AnalysisResponse) -> Unit,
+    authViewModel: AuthViewModel
 ) {
+    val userState by authViewModel.user.collectAsState()
+    val userName = userState?.fullName ?: "사용자"
+
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = Primary100
@@ -72,15 +77,14 @@ fun MainScreen(
                 .padding(horizontal = 24.dp)
                 .verticalScroll(rememberScrollState())
         ) {
-
             Spacer(modifier = Modifier.height(32.dp))
 
             // 상단 바
-            TopBar()
+            TopBar(userName = userName)
             Spacer(modifier = Modifier.height(103.dp))
 
             // 환영 메시지
-            Greeting()
+            Greeting(userName = userName)
             Spacer(modifier = Modifier.height(32.dp))
 
             // 파일 업로드 카드
@@ -108,7 +112,7 @@ fun MainScreen(
 }
 
 @Composable
-fun TopBar() {
+fun TopBar(userName: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -121,13 +125,13 @@ fun TopBar() {
         ) {
             Box(
                 modifier = Modifier
-                    .size(40.dp)
+                    .size(32.dp)
                     .clip(CircleShape)
                     .background(Grayscale300)
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(
-                text = "홍길동",
+                text = userName,
                 style = AppTypography.titleMedium,
                 color = Grayscale800
             )
@@ -137,18 +141,18 @@ fun TopBar() {
             Icon(
                 imageVector = Icons.Default.Menu,
                 contentDescription = "Menu",
-                modifier = Modifier.size(28.dp)
+                modifier = Modifier.size(24.dp)
             )
         }
     }
 }
 
 @Composable
-fun Greeting() {
+fun Greeting(userName: String) {
     Column {
         Row(verticalAlignment = Alignment.Bottom) {
             Text(
-                text = "홍길동",
+                text = userName,
                 style = AppTypography.headlineLarge.copy(
                     fontFamily = NPSFont,
                     fontWeight = FontWeight.Normal
@@ -248,17 +252,6 @@ fun HelpSection(modifier: Modifier = Modifier) {
             modifier = Modifier.clickable { /* No action */ },
             style = AppTypography.bodyMedium,
             color = Grayscale600
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun MainScreenPreview() {
-    AntiPhishingAppTheme {
-        MainScreen(
-            navController = rememberNavController(),
-            onAnalysisComplete = {}
         )
     }
 }

--- a/app/src/main/java/com/example/antiphishingapp/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/antiphishingapp/ui/navigation/AppNavGraph.kt
@@ -9,7 +9,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.antiphishingapp.feature.model.AnalysisResponse
 import com.example.antiphishingapp.feature.viewmodel.LoginViewModel
-import com.example.antiphishingapp.feature.viewmodel.SocialLoginViewModel
 import com.example.antiphishingapp.ui.screen.FileUploadScreen
 import com.example.antiphishingapp.ui.screen.AnalysisScreen
 import com.example.antiphishingapp.ui.screen.RealtimeScreen
@@ -18,10 +17,12 @@ import com.example.antiphishingapp.ui.screen.DetectHistoryScreen
 import com.example.antiphishingapp.ui.screen.SignUpScreen
 import com.example.antiphishingapp.ui.screen.TitleScreen
 import com.example.antiphishingapp.ui.screen.LoginScreen
+import com.example.antiphishingapp.viewmodel.AuthViewModel
 
 @Composable
 fun AppNavGraph(navController: NavHostController, startRoute: String) {
     val analysisResult = remember { mutableStateOf<AnalysisResponse?>(null) }
+    val authViewModel: AuthViewModel = viewModel()
 
     NavHost(
         navController = navController,
@@ -41,6 +42,7 @@ fun AppNavGraph(navController: NavHostController, startRoute: String) {
         composable("main") {
             MainScreen(
                 navController = navController,
+                authViewModel = authViewModel,
                 onAnalysisComplete = { result ->
                     analysisResult.value = result
                     navController.navigate("analysis")
@@ -50,12 +52,18 @@ fun AppNavGraph(navController: NavHostController, startRoute: String) {
 
         // ✅ 파일 업로드 화면
         composable("fileUpload") {
-            FileUploadScreen(navController = navController)
+            FileUploadScreen(
+                navController = navController,
+                authViewModel = authViewModel
+            )
         }
 
         // ✅ 탐지 기록 화면
         composable("detectHistory") {
-            DetectHistoryScreen(navController = navController)
+            DetectHistoryScreen(
+                navController = navController,
+                authViewModel = authViewModel,
+            )
         }
 
         // ✅ 회원가입 화면

--- a/app/src/main/java/com/example/antiphishingapp/ui/screen/DetectHistoryScreen.kt
+++ b/app/src/main/java/com/example/antiphishingapp/ui/screen/DetectHistoryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -57,11 +58,16 @@ import com.example.antiphishingapp.theme.Primary100
 import com.example.antiphishingapp.theme.Primary200
 import com.example.antiphishingapp.theme.Primary300
 import com.example.antiphishingapp.theme.Primary900
+import com.example.antiphishingapp.viewmodel.AuthViewModel
 
 @Composable
 fun DetectHistoryScreen(
-    navController: NavController
+    navController: NavController,
+    authViewModel: AuthViewModel
 ) {
+    val userState by authViewModel.user.collectAsState()
+    val userName = userState?.fullName ?: "사용자"
+
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = Primary100
@@ -74,8 +80,7 @@ fun DetectHistoryScreen(
         ) {
             Spacer(modifier = Modifier.height(32.dp))
 
-            // 공통 TopBar
-            TopBar()
+            TopBar(userName = userName)
             Spacer(modifier = Modifier.height(62.dp))
 
             // 헤더
@@ -107,7 +112,7 @@ fun DetectHistoryScreen(
 }
 
 @Composable
-private fun TopBar() {
+private fun TopBar(userName: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -120,13 +125,13 @@ private fun TopBar() {
         ) {
             Box(
                 modifier = Modifier
-                    .size(40.dp)
+                    .size(32.dp)
                     .clip(CircleShape)
                     .background(Grayscale300)
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(
-                text = "홍길동",
+                text = userName,
                 style = AppTypography.titleMedium,
                 color = Grayscale800
             )
@@ -136,7 +141,7 @@ private fun TopBar() {
             Icon(
                 imageVector = Icons.Default.Menu,
                 contentDescription = "Menu",
-                modifier = Modifier.size(28.dp)
+                modifier = Modifier.size(24.dp)
             )
         }
     }
@@ -254,16 +259,6 @@ private fun HelpSection(modifier: Modifier = Modifier) {
             modifier = Modifier.clickable { /* No action */ },
             style = AppTypography.bodyMedium,
             color = Grayscale600
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DetectHistoryScreenPreview() {
-    AntiPhishingAppTheme {
-        DetectHistoryScreen(
-            navController = rememberNavController()
         )
     }
 }

--- a/app/src/main/java/com/example/antiphishingapp/ui/screen/FileUploadScreen.kt
+++ b/app/src/main/java/com/example/antiphishingapp/ui/screen/FileUploadScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -57,11 +58,15 @@ import com.example.antiphishingapp.theme.Primary100
 import com.example.antiphishingapp.theme.Primary200
 import com.example.antiphishingapp.theme.Primary300
 import com.example.antiphishingapp.theme.Primary900
+import com.example.antiphishingapp.viewmodel.AuthViewModel
 
 @Composable
 fun FileUploadScreen(
-    navController: NavController
+    navController: NavController,
+    authViewModel: AuthViewModel
 ) {
+    val userState by authViewModel.user.collectAsState()
+    val userName = userState?.fullName ?: "사용자"
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = Primary100
@@ -74,7 +79,7 @@ fun FileUploadScreen(
         ) {
             Spacer(modifier = Modifier.height(32.dp))
 
-            TopBar()
+            TopBar(userName = userName)
             Spacer(modifier = Modifier.height(62.dp))
 
             FileUploadHeader()
@@ -102,7 +107,7 @@ fun FileUploadScreen(
 }
 
 @Composable
-private fun TopBar() {
+private fun TopBar(userName: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -115,13 +120,13 @@ private fun TopBar() {
         ) {
             Box(
                 modifier = Modifier
-                    .size(40.dp)
+                    .size(32.dp)
                     .clip(CircleShape)
                     .background(Grayscale300)
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(
-                text = "홍길동",
+                text = userName,
                 style = AppTypography.titleMedium,
                 color = Grayscale800
             )
@@ -131,7 +136,7 @@ private fun TopBar() {
             Icon(
                 imageVector = Icons.Default.Menu,
                 contentDescription = "Menu",
-                modifier = Modifier.size(28.dp)
+                modifier = Modifier.size(24.dp)
             )
         }
     }
@@ -253,16 +258,6 @@ private fun HelpSection(modifier: Modifier = Modifier) {
             modifier = Modifier.clickable { /* No action */ },
             style = AppTypography.bodyMedium,
             color = Grayscale600
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun FileUploadScreenPreview() {
-    AntiPhishingAppTheme {
-        FileUploadScreen(
-            navController = rememberNavController()
         )
     }
 }


### PR DESCRIPTION
- AuthViewModel을 AndroidViewModel로 변경하여 ApplicationContext 자동 주입
- AuthRepository(context) 사용 구조와 일관성 유지
- AppNavGraph에서 AuthViewModel을 viewModel()로 생성하도록 수정
- MainScreen, DetectHistoryScreen, FileUploadScreen에서 AuthViewModel의 사용자 정보를 구독하여 username 표시
- TopBar/Greeting 컴포넌트에 사용자 이름 동적 반영
- 전체 ViewModel 패턴(Login/SocialLogin 등)과 구조를 통일하여 유지보수성 개선