### PR TITLE
fix: 소셜 로그인 연결 오류 해결 (#57)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
+            android:launchMode="singleTask" android:label="@string/app_name"
             android:theme="@style/Theme.AntiPhishingApp">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -60,14 +60,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:host="oauth" android:scheme="kakao" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="antiphishingapp" android:host="navercallback" />
+                <data android:host="oauth" android:scheme="antiphishing" />
             </intent-filter>
 
             <intent-filter>

--- a/app/src/main/java/com/example/antiphishingapp/network/AppConfig.kt
+++ b/app/src/main/java/com/example/antiphishingapp/network/AppConfig.kt
@@ -7,12 +7,12 @@ object AppConfig {
 
     // --- 카카오 설정 ---
     const val KAKAO_CLIENT_ID = "cc9b60d42f687ae216470e85c98822f0"
-    const val KAKAO_REDIRECT_URI = "http://localhost:8000/auth/kakao/callback"
+    const val KAKAO_REDIRECT_URI = "antiphishing://oauth/kakao/callback"
     const val KAKAO_AUTH_URL = "https://kauth.kakao.com/oauth/authorize"
 
     // --- 네이버 설정 ---
     const val NAVER_CLIENT_ID = "17faQV8AGa02hywfsUTn"
     const val NAVER_CLIENT_SECRET = "vnimMcgfoL"
-    const val NAVER_REDIRECT_URI = "http://localhost:8000/auth/naver/callback"
+    const val NAVER_REDIRECT_URI = "antiphishing://oauth/naver/callback"
     const val NAVER_AUTH_URL = "https://nid.naver.com/oauth2.0/authorize"
 }

--- a/app/src/main/java/com/example/antiphishingapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/antiphishingapp/ui/MainActivity.kt
@@ -41,6 +41,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        handleSocialLoginIntent(intent)
+
         // AuthRepository 초기화
         authRepository = AuthRepository(applicationContext)
 
@@ -183,12 +185,17 @@ class MainActivity : ComponentActivity() {
      */
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
+        handleSocialLoginIntent(intent)
+    }
 
-        val uri: Uri? = intent.data
-
-        if (intent.action == Intent.ACTION_VIEW && uri != null) {
-            Log.d("SOCIAL_LOGIN", "Received callback URI: $uri")
-            SocialLoginCallbackHandler.handleUri(uri)
+    private fun handleSocialLoginIntent(intent: Intent?) {
+        val uri: Uri? = intent?.data
+        if (intent?.action == Intent.ACTION_VIEW && uri != null) {
+            if (uri.scheme == "antiphishing") {
+                Log.d("SOCIAL_LOGIN", "Received callback URI: $uri")
+                SocialLoginCallbackHandler.handleUri(uri)
+            }
         }
     }
 }


### PR DESCRIPTION
[문제 원인]
- Redirect URI 불일치: AppConfig.kt 내의 리다이렉트 주소가 모바일 환경에서 접근할 수 없는 웹용 주소 (http://localhost:8000) 로 설정되어 있어 ERR_CONNECTION_REFUSED 오류 발생.
- Intent Filter 부재: 인증 후 브라우저에서 앱으로 돌아오려 할 때, 해당 스키마(antiphishing://)를 수신할 intent-filter가 AndroidManifest.xml에 정의되지 않음.
- Activity 중복 실행: 로그인 완료 후 앱으로 복귀 시 MainActivity가 재실행되는 문제 가능성 존재 (singleTask 미설정).

[변경 사항]
- AppConfig: Redirect URI를 웹(localhost)에서 앱 스키마(antiphishing://)로 변경
- AndroidManifest: MainActivity에 singleTask 모드 및 intent-filter 통합 적용
- MainActivity: 딥링크 수신 로직(handleSocialLoginIntent) 추가

[해결 문제]
- 소셜 로그인 연결 오류 해결

Closes #57