### PR TITLE
fix: 이미지 업로드 결과 화면 UI(폰트, 아이콘) 미적용 문제 해결 (#59)

### DIFF
--- a/app/src/main/java/com/example/antiphishingapp/ui/screen/ImageUploadResultScreen.kt
+++ b/app/src/main/java/com/example/antiphishingapp/ui/screen/ImageUploadResultScreen.kt
@@ -98,6 +98,7 @@ fun ImageUploadResultScreen(
                         Text(
                             text = "$forgeryScore%",
                             style = MaterialTheme.typography.displayMedium.copy(
+                                fontFamily = Pretendard,
                                 fontWeight = FontWeight.Bold,
                                 color = scoreColor
                             ),
@@ -347,7 +348,11 @@ fun InteractiveResultButton(text: String, onClick: () -> Unit) {
             .fillMaxWidth(0.9f)
             .height(52.dp)
     ) {
-        Icon(imageVector = Icons.Default.Search, contentDescription = null, modifier = Modifier.size(20.dp))
+        Icon(
+            painter = painterResource(id = R.drawable.mag),
+            contentDescription = "Search Icon",
+            modifier = Modifier.size(20.dp)
+        )
         Spacer(Modifier.width(8.dp))
         Text(text, fontWeight = FontWeight.Bold)
     }


### PR DESCRIPTION
## 🔧 PR 제목
이미지 업로드 결과 화면 UI(폰트, 아이콘) 미적용 문제 해결 (#59)

---

## 🐞 문제 원인 (Root Cause)
- 위험도 점수(`$forgeryScore%`) 텍스트에 커스텀 폰트(Pretendard)가 명시적으로 적용되지 않아 시스템 기본 폰트로 노출됨.
- `InteractiveResultButton` 내부 아이콘이 피그마 디자인(`mag.png`)이 아닌 Material Default Search 아이콘으로 설정되어 있었음.

---

## 🔨 해결 내용 (What I Fixed)
- 위험도 점수 Text 스타일에 `fontFamily = Pretendard` 속성을 추가하여 폰트 강제 적용 (LocalTextStyle Override).
- 버튼 내부 `Icon`을 `imageVector` 방식에서 `painterResource(id = R.drawable.mag)`로 변경하여 디자인과 일치시킴.
- `theme` 패키지의 폰트 설정이 올바르게 반영되도록 Import 및 스타일 적용 확인.

---

## 📱 수정 후 동작 화면 (Screenshots)

| Before (수정 전) | After (수정 후) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/231b79d0-a034-4ab8-b47c-79597d96e29a" width="300" /> | <img src="https://github.com/user-attachments/assets/85bd6ec7-184b-4667-a8df-890a2250775a" width="300" /> |

---

## 🧪 테스트 내역 (Test Checklist)

### UI 디자인 정합성 확인
- [x] 위험도 % 텍스트가 `Pretendard` 폰트로 정상 표시됨
- [x] '이미지 탐지 결과 살펴보기' 버튼의 돋보기 아이콘이 디자인 시안과 일치함

---

## 🔗 관련 Issue
- Related to #59